### PR TITLE
feat: add PHP and multi-language support to file indexing

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codeseeker",
-  "version": "1.7.2",
+  "version": "1.8.0",
   "description": "Graph-powered code intelligence for Claude Code. Semantic search + knowledge graph for better AI code understanding.",
   "main": "dist/index.js",
   "bin": {

--- a/plugins/codeseeker/.claude-plugin/plugin.json
+++ b/plugins/codeseeker/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "codeseeker",
-  "version": "1.7.2",
+  "version": "1.8.0",
   "description": "CodeSeeker - Intelligent code understanding with semantic search, knowledge graphs, and auto-detected coding standards",
   "author": {
     "name": "CodeSeeker Team",

--- a/plugins/codeseeker/version.json
+++ b/plugins/codeseeker/version.json
@@ -1,6 +1,6 @@
 {
-  "version": "1.7.2",
-  "releaseDate": "2026-01-20",
+  "version": "1.8.0",
+  "releaseDate": "2026-02-07",
   "minCliVersion": "1.0.1",
   "changelog": "https://github.com/jghiringhelli/codeseeker/releases",
   "updateCommand": "/plugin uninstall codeseeker && /plugin install codeseeker@github:jghiringhelli/codeseeker#plugin"

--- a/src/cli/commands/handlers/search-command-handler.ts
+++ b/src/cli/commands/handlers/search-command-handler.ts
@@ -105,9 +105,9 @@ export class SearchCommandHandler extends BaseCommandHandler {
 
     try {
       // Get all code files
-      const files = await glob(['**/*.{ts,js,jsx,tsx,py,java,cs,cpp,c,h,hpp}'], {
+      const files = await glob(['**/*.{ts,js,jsx,tsx,py,java,cs,cpp,c,h,hpp,php,rb,go,rs,swift,kt,scala}'], {
         cwd: projectPath,
-        ignore: ['**/node_modules/**', '**/dist/**', '**/build/**', '**/.git/**']
+        ignore: ['**/node_modules/**', '**/vendor/**', '**/dist/**', '**/build/**', '**/.git/**']
       });
 
       console.log(`📂 Found ${files.length} files to scan`);

--- a/src/cli/services/search/semantic-search.ts
+++ b/src/cli/services/search/semantic-search.ts
@@ -56,8 +56,8 @@ export class SemanticSearchService extends AnalysisTool implements IProjectIndex
 
   // Configuration
   private config = {
-    supportedExtensions: ['.ts', '.js', '.py', '.java', '.go', '.rs', '.cpp', '.c', '.h'],
-    excludePatterns: ['node_modules', '.git', 'dist', 'build', 'coverage'],
+    supportedExtensions: ['.ts', '.js', '.py', '.java', '.go', '.rs', '.cpp', '.c', '.h', '.php', '.rb', '.swift', '.kt', '.scala', '.cs'],
+    excludePatterns: ['node_modules', 'vendor', '.git', 'dist', 'build', 'coverage'],
     batchSize: 50,
     enableCaching: true
   };


### PR DESCRIPTION
- Add .php, .rb, .go, .rs, .swift, .kt, .scala extensions to glob pattern
- Add vendor/ to ignore patterns for PHP projects
- Update semantic search config with new extensions
- Bump version to 1.8.0 (MINOR - new feature)

Fixes issue where PHP projects showed 0 files to scan during indexing. Now supports: TypeScript, JavaScript, Python, Java, PHP, Ruby, Go, Rust, C/C++, C#, Swift, Kotlin, and Scala.